### PR TITLE
Fly.ymlの作成と自動デプロイのテスト

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,16 @@
+mkdir -p .github/workflows
+echo "name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: \${{ secrets.FLY_API_TOKEN }}" > .github/workflows/fly.yml

--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ My Song Journalは、毎日の気分に合わせて曲と一言メモを記録�
 - **API**: Spotify Web API (楽曲データ取得、再生)
 - **ユーザー認証**: Devise + OAuth（Spotify）
 - **デプロイ**: fly.io
-
 ---

--- a/README.md
+++ b/README.md
@@ -101,6 +101,4 @@ My Song Journalは、毎日の気分に合わせて曲と一言メモを記録�
 - **API**: Spotify Web API (楽曲データ取得、再生)
 - **ユーザー認証**: Devise + OAuth（Spotify）
 - **デプロイ**: fly.io
-  
-
 ---

--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ My Song Journalは、毎日の気分に合わせて曲と一言メモを記録�
 - **API**: Spotify Web API (楽曲データ取得、再生)
 - **ユーザー認証**: Devise + OAuth（Spotify）
 - **デプロイ**: fly.io
+
 ---


### PR DESCRIPTION
.github/workflows/fly.yml
```
mkdir -p .github/workflows
echo "name: Fly Deploy
on:
  push:
    branches:
      - main
jobs:
  deploy:
    name: Deploy app
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: superfly/flyctl-actions/setup-flyctl@master
      - run: flyctl deploy --remote-only
        env:
          FLY_API_TOKEN: \${{ secrets.FLY_API_TOKEN }}" > .github/workflows/fly.yml

```

の作成

mainにpushをするとfly.ioで自動デプロイされるようにしたいです

