### PR TITLE
Auto deployment test

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,9 +1,10 @@
-mkdir -p .github/workflows
-echo "name: Fly Deploy
+name: Fly Deploy
+
 on:
   push:
     branches:
       - main
+
 jobs:
   deploy:
     name: Deploy app
@@ -13,4 +14,4 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:
-          FLY_API_TOKEN: \${{ secrets.FLY_API_TOKEN }}" > .github/workflows/fly.yml
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ My Song Journalは、毎日の気分に合わせて曲と一言メモを記録�
 - **API**: Spotify Web API (楽曲データ取得、再生)
 - **ユーザー認証**: Devise + OAuth（Spotify）
 - **デプロイ**: fly.io
+
 ---


### PR DESCRIPTION
構文エラーを修正しました
```
name: Fly Deploy

on:
  push:
    branches:
      - main

jobs:
  deploy:
    name: Deploy app
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: superfly/flyctl-actions/setup-flyctl@master
      - run: flyctl deploy --remote-only
        env:
          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


```

FLY_API_TOKEN 環境変数の設定で、エスケープ文字 \ が不要です。 ${{ secrets.FLY_API_TOKEN }} とそのまま記載しています
