### PR TITLE
fly.ioのデプロイにおける問題点の修正（puma.rb）

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,8 @@ plugin :tmp_restart
 # Run the Solid Queue supervisor inside of Puma for single-server deployments
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
 
+bind "tcp://0.0.0.0:3000"
+
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end


### PR DESCRIPTION
### **概要**
Fly.ioへのデプロイ時に発生した以下の問題を修正しました：
- Fly.io側のログにおいて、「is your app listening on 0.0.0.0:3000?」というエラーが発生していた。
- アプリケーションのルーティングが正しく設定されていないため、`ActionController::RoutingError (No route matches [GET] "/")` が発生していた。


### **修正内容**
1. **Puma設定の修正**
   - `config/puma.rb` ファイルに `bind "tcp://0.0.0.0:3000"` を追加。
   - Fly.ioが指定するポートでリッスンできるように設定。

2. **ルーティングの修正**
   - `config/routes.rb` に `root "home#index"` を追加。
   - デフォルトのルートパスを設定。